### PR TITLE
remove the link for supply chain pm role since it is no longer active

### DIFF
--- a/jobs.md
+++ b/jobs.md
@@ -15,9 +15,6 @@ Interested in working on open source and containers at a leading hyper-scale clo
 _coming soon_
 
 ### Program Manager
-#### Secure supply chain
-- [Senior Program Manager, Atlanta, remote](https://careers.microsoft.com/us/en/job/1203784/Senior-Program-Manager-Azure-Core-Upstream)
-
 #### Service Mesh
 - [Senior Program Manager, Atlanta, remote](https://careers.microsoft.com/us/en/job/1307646/Senior-Product-Manager-Open-Service-Mesh)
 


### PR DESCRIPTION
The link to this role leads to a close req, so removing it. Do we want to leave the secure supply chain header in place for future roles?